### PR TITLE
fix(modelGenerator): Use deepClone instead of shallow clone

### DIFF
--- a/src/modelGenerator.js
+++ b/src/modelGenerator.js
@@ -1,4 +1,4 @@
-import clone from 'mout/src/lang/clone';
+import clone from 'mout/src/lang/deepClone';
 
 /* eslint-disable no-new-func */
 


### PR DESCRIPTION
Fixes bug where multiple cells shared materials due to materials and
radii arrays being shared.