### PR TITLE
Renaming to align with docs+model

### DIFF
--- a/src/components/core/PropertyPanel/script.js
+++ b/src/components/core/PropertyPanel/script.js
@@ -13,7 +13,7 @@ export default {
     PropertyFactory,
   },
   props: {
-    panelData: {
+    panelAttributes: {
       required: true,
     },
     viewData: {

--- a/src/components/core/PropertyPanel/script.js
+++ b/src/components/core/PropertyPanel/script.js
@@ -13,7 +13,7 @@ export default {
     PropertyFactory,
   },
   props: {
-    input: {
+    panelData: {
       required: true,
     },
     viewData: {

--- a/src/components/core/PropertyPanel/template.html
+++ b/src/components/core/PropertyPanel/template.html
@@ -4,18 +4,18 @@
 >
   <v-layout row wrap>
     <v-flex
-      v-for="property in input"
-      :key="property.title"
+      v-for="attribute in panelData"
+      :key="attribute.title"
       xs12
     >
-      <div :style="{ display: getPropertyDisplay(property) }">
+      <div :style="{ display: getPropertyDisplay(attribute) }">
         <v-card>
-          <v-card-title :class="$style.propertyHeader">{{ property.title }}</v-card-title>
+          <v-card-title :class="$style.propertyHeader">{{ attribute.title }}</v-card-title>
           <v-card-text>
-            <template v-for="(content, i) in property.contents">
+            <template v-for="(parameter, i) in attribute.contents">
               <property-factory
                 :key="i"
-                :prop="content"
+                :prop="parameter"
                 :viewData="viewData"
                 @change="updateViewData"
               />

--- a/src/components/core/PropertyPanel/template.html
+++ b/src/components/core/PropertyPanel/template.html
@@ -4,7 +4,7 @@
 >
   <v-layout row wrap>
     <v-flex
-      v-for="attribute in panelData"
+      v-for="attribute in panelAttributes"
       :key="attribute.title"
       xs12
     >

--- a/src/components/core/WorkflowContent/template.html
+++ b/src/components/core/WorkflowContent/template.html
@@ -1,6 +1,6 @@
 <v-container fluid :class="$style.container">
   <property-panel
-    :input="panelData"
+    :panelData="panelData"
     :viewData="viewData"
   />
 </v-container>

--- a/src/components/core/WorkflowContent/template.html
+++ b/src/components/core/WorkflowContent/template.html
@@ -1,6 +1,6 @@
 <v-container fluid :class="$style.container">
   <property-panel
-    :panelData="panelData"
+    :panelAttributes="panelData"
     :viewData="viewData"
   />
 </v-container>


### PR DESCRIPTION
The docs and model specify a View/Attribute/Parameter hierarchy which I find clearer than the use of `property` below. 

This should change no functionality. I tested by filling in some fields and seeing the updates correctly found their fields. 

I'm stopping short of changing "Panel" to View since that would change the public API. 